### PR TITLE
[RDVAULT-10] Networking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ install:
 script:
   # Validate our Ansible playbooks
   - python -myamllint -f parsable playbook.yml
-  - ansible-lint -p playbook.yml
+  # ANSIBLE0012 seems like it's usually good practice, but doesn't really suit our use case here - if we tell it to publish, we want it to publish
+  - ansible-lint -p playbook.yml -x ANSIBLE0012
   # TODO Add additional validation/build steps here
 
 notifications:

--- a/aws/README.md
+++ b/aws/README.md
@@ -60,11 +60,15 @@ We have (currently) one *ECS cluster*, rdss-datavault.
 This cluster is made up of *EC2* instances (The eu-west-2 region does not support the use of Fargate).
 These instances are created and managed by an *EC2 Auto Scaling Group*, which defines the desired number of instances, and the configuration each instance is launched with.
 When an instance is created, a launch script is executed which connects it to the ECS cluster.
-At present, the group has only a single instance, and it can only be scaled manually; no automatic scaling has been configured.
+At present, the group has two instances, and can only be scaled manually; no automatic scaling has been configured.
 
 Each of the four component parts of DataVault is defined as an *ECS task* which contains the relevant container, and each has a related *ECS service*.
 ECS ensures that there is always one task running for each service (if a tasks exits, it will be restarted), by deploying it to one of the instances in the cluster.
-At present, the containers cannot communicate between each other (and so several will not start cleanly).
+
+For communication between containers, and with the outside world, each service is associated with a *Load Balancer*, either an *Application Load Balancer* or a *Classic Load Balancer* as appropriate.
+Each Load Balancer has an associated *Route 53* entry, essentially a DNS name.
+When one container (e.g web) needs to communicate with another (e.g. broker), it uses this DNS name.
+The names are not resolveable externally.
 
 There is a MySQL database created using *RDS*, which the broker and workers communicate with.
 

--- a/aws/cloudwatch.tf
+++ b/aws/cloudwatch.tf
@@ -1,9 +1,11 @@
 resource "aws_cloudwatch_log_group" "datavault" {
   name = "datavault"
   tags = "${var.aws_cost_tags}"
+  retention_in_days = "${var.aws_cloudwatch_log_retention_days}"
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {
   name = "ecs-agent"
   tags = "${var.aws_cost_tags}"
+  retention_in_days = "${var.aws_cloudwatch_log_retention_days}"
 }

--- a/aws/ecs.ec2-instances.tf
+++ b/aws/ecs.ec2-instances.tf
@@ -1,6 +1,6 @@
 resource "aws_autoscaling_group" "app" {
   name                 = "asg"
-  vpc_zone_identifier  = ["${data.aws_subnet.main.id}"]
+  vpc_zone_identifier  = ["${data.aws_subnet.a.id}", "${data.aws_subnet.b.id}", "${data.aws_subnet.c.id}"]
   min_size             = "${var.aws_ecs_asg_size["min"]}"
   max_size             = "${var.aws_ecs_asg_size["max"]}"
   desired_capacity     = "${var.aws_ecs_asg_size["desired"]}"
@@ -50,6 +50,13 @@ resource "aws_security_group" "instance_sg" {
     from_port       = 80
     to_port         = 80
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 0
+    to_port         = 65535
+    security_groups = ["${aws_security_group.rdss_datavault_broker.id}"]
   }
 
   egress {

--- a/aws/ecs.ec2-instances.tf
+++ b/aws/ecs.ec2-instances.tf
@@ -56,7 +56,7 @@ resource "aws_security_group" "instance_sg" {
     protocol        = "tcp"
     from_port       = 0
     to_port         = 65535
-    security_groups = ["${aws_security_group.rdss_datavault_broker.id}"]
+    security_groups = ["${aws_security_group.rdss_datavault_broker.id}","${aws_security_group.rdss_datavault_rabbitmq.id}"]
   }
 
   egress {

--- a/aws/ecs.ec2-instances.tf
+++ b/aws/ecs.ec2-instances.tf
@@ -47,16 +47,9 @@ resource "aws_security_group" "instance_sg" {
 
   ingress {
     protocol        = "tcp"
-    from_port       = 80
-    to_port         = 80
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    protocol        = "tcp"
     from_port       = 0
     to_port         = 65535
-    security_groups = ["${aws_security_group.rdss_datavault_broker.id}","${aws_security_group.rdss_datavault_rabbitmq.id}"]
+    security_groups = ["${aws_security_group.rdss_datavault_broker.id}","${aws_security_group.rdss_datavault_rabbitmq.id}","${aws_security_group.rdss_datavault_web.id}"]
   }
 
   egress {

--- a/aws/ecs.iam.tf
+++ b/aws/ecs.iam.tf
@@ -1,5 +1,45 @@
 # Used by the ECS Services.
 
+resource "aws_iam_role" "ecs_task" {
+  name = "ecs-task-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "ecs_task" {
+  name = "ecs_task_policy"
+  role = "${aws_iam_role.ecs_task.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": "${aws_s3_bucket.archive.arn}/*"
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_role" "ecs_service" {
   name = "ecs-service-role"
 
@@ -39,13 +79,6 @@ resource "aws_iam_role_policy" "ecs_service" {
         "elasticloadbalancing:RegisterTargets"
       ],
       "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:*"
-      ],
-      "Resource": "${aws_s3_bucket.archive.arn}"
     }
   ]
 }

--- a/aws/ecs.svc-broker.tf
+++ b/aws/ecs.svc-broker.tf
@@ -21,6 +21,7 @@ resource "aws_ecs_task_definition" "rdss_datavault_broker" {
   family                = "rdss-datavault-broker"
   container_definitions = "${data.template_file.task_definition_broker.rendered}"
   network_mode          = "bridge"
+  task_role_arn         = "${aws_iam_role.ecs_task.arn}"
 
   # This volume has to be shared with the worker task, in order for the broker to access the metadata after the worker has updated it
   # That's a bug - the worker should instead send the metadata back via rabbitmq - once it's fixed the volume can be removed/unshared

--- a/aws/ecs.svc-broker.tf
+++ b/aws/ecs.svc-broker.tf
@@ -10,6 +10,8 @@ data "template_file" "task_definition_broker" {
     archive_bucket_name = "${aws_s3_bucket.archive.bucket}"
     mysql_host          = "${aws_db_instance.datavault.address}"
     mysql_password      = "${var.mysql_password}"
+    rabbitmq_host       = "127.0.0.1"
+    rabbitmq_password   = "${var.rabbitmq_password}"
     volume_name         = "datavault_working_data"
   }
 }

--- a/aws/ecs.svc-broker.tf
+++ b/aws/ecs.svc-broker.tf
@@ -32,9 +32,86 @@ resource "aws_ecs_task_definition" "rdss_datavault_broker" {
 }
 
 resource "aws_ecs_service" "rdss_datavault_broker" {
-  name            = "rdss-datavault-broker"
-  cluster         = "${aws_ecs_cluster.main.id}"
-  task_definition = "${aws_ecs_task_definition.rdss_datavault_broker.arn}"
-  desired_count   = 1
-  depends_on      = ["aws_iam_role_policy.ecs_service"]
+  name                              = "rdss-datavault-broker"
+  cluster                           = "${aws_ecs_cluster.main.id}"
+  task_definition                   = "${aws_ecs_task_definition.rdss_datavault_broker.arn}"
+  desired_count                     = 1
+  depends_on                        = ["aws_iam_role_policy.ecs_service"]
+  health_check_grace_period_seconds = 300
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.rdss_datavault_broker.arn}"
+    container_name   = "rdss-datavault-broker"
+    container_port   = 8080
+  }
 }
+
+resource "aws_route53_record" "rdss_datavault_broker" {
+  zone_id = "${aws_route53_zone.internal.zone_id}"
+  name    = "broker.${aws_route53_zone.internal.name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.rdss_datavault_broker.dns_name}"
+    zone_id                = "${aws_lb.rdss_datavault_broker.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_lb" "rdss_datavault_broker" {
+  name                       = "rdss-datavault-broker-lb"
+  internal                   = true
+  load_balancer_type         = "application"
+  security_groups            = ["${aws_security_group.rdss_datavault_broker.id}"]
+  subnets                    = ["${data.aws_subnet.a.id}", "${data.aws_subnet.b.id}", "${data.aws_subnet.c.id}"]
+  tags                       = "${var.aws_cost_tags}"
+}
+
+resource "aws_lb_listener" "rdss_datavault_broker" {
+  load_balancer_arn = "${aws_lb.rdss_datavault_broker.arn}"
+  port              = "8080"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.rdss_datavault_broker.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_target_group" "rdss_datavault_broker" {
+  name        = "rdss-datavault-broker-lb-tg"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = "${data.aws_vpc.main.id}"
+  target_type = "instance"
+}
+
+resource "aws_security_group" "rdss_datavault_broker" {
+  description = "Controls access to Broker"
+  vpc_id      = "${data.aws_vpc.main.id}"
+  name        = "rdss-datavault-broker-sg"
+  tags        = "${var.aws_cost_tags}"
+}
+
+resource "aws_security_group_rule" "rdss_datavault_broker_ingress" {
+  # This cannot be specified as an inline ingress block in aws_security_group.rdss_datavault_broker
+  # as this causes a cyclic dependency error
+  security_group_id        = "${aws_security_group.rdss_datavault_broker.id}"
+  type                     = "ingress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.instance_sg.id}"
+}
+
+resource "aws_security_group_rule" "rdss_datavault_broker_egress" {
+  # This cannot be specified as an inline egress block in aws_security_group.rdss_datavault_broker
+  # because of aws_security_group_rule.rdss_datavault_broker_ingress
+  security_group_id = "${aws_security_group.rdss_datavault_broker.id}"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+

--- a/aws/ecs.svc-broker.tf
+++ b/aws/ecs.svc-broker.tf
@@ -10,7 +10,8 @@ data "template_file" "task_definition_broker" {
     archive_bucket_name = "${aws_s3_bucket.archive.bucket}"
     mysql_host          = "${aws_db_instance.datavault.address}"
     mysql_password      = "${var.mysql_password}"
-    rabbitmq_host       = "127.0.0.1"
+    # This is the gateway of the Docker daemon, and only works as long as a) broker & rabbitmq are on same host & b) Docker IP range doesn't change
+    rabbitmq_host       = "172.17.0.1"
     rabbitmq_password   = "${var.rabbitmq_password}"
     volume_name         = "datavault_working_data"
   }

--- a/aws/ecs.svc-broker.tf
+++ b/aws/ecs.svc-broker.tf
@@ -19,6 +19,7 @@ data "template_file" "task_definition_broker" {
 resource "aws_ecs_task_definition" "rdss_datavault_broker" {
   family                = "rdss-datavault-broker"
   container_definitions = "${data.template_file.task_definition_broker.rendered}"
+  network_mode          = "bridge"
 
   # This volume has to be shared with the worker task, in order for the broker to access the metadata after the worker has updated it
   # That's a bug - the worker should instead send the metadata back via rabbitmq - once it's fixed the volume can be removed/unshared

--- a/aws/ecs.svc-broker.tf
+++ b/aws/ecs.svc-broker.tf
@@ -10,8 +10,7 @@ data "template_file" "task_definition_broker" {
     archive_bucket_name = "${aws_s3_bucket.archive.bucket}"
     mysql_host          = "${aws_db_instance.datavault.address}"
     mysql_password      = "${var.mysql_password}"
-    # This is the gateway of the Docker daemon, and only works as long as a) broker & rabbitmq are on same host & b) Docker IP range doesn't change
-    rabbitmq_host       = "172.17.0.1"
+    rabbitmq_host       = "${aws_route53_record.rdss_datavault_rabbitmq.fqdn}"
     rabbitmq_password   = "${var.rabbitmq_password}"
     volume_name         = "datavault_working_data"
   }
@@ -54,7 +53,7 @@ resource "aws_route53_record" "rdss_datavault_broker" {
   alias {
     name                   = "${aws_lb.rdss_datavault_broker.dns_name}"
     zone_id                = "${aws_lb.rdss_datavault_broker.zone_id}"
-    evaluate_target_health = true
+    evaluate_target_health = false
   }
 }
 
@@ -69,7 +68,7 @@ resource "aws_lb" "rdss_datavault_broker" {
 
 resource "aws_lb_listener" "rdss_datavault_broker" {
   load_balancer_arn = "${aws_lb.rdss_datavault_broker.arn}"
-  port              = "8080"
+  port              = 8080
   protocol          = "HTTP"
 
   default_action {

--- a/aws/ecs.svc-rabbitmq.tf
+++ b/aws/ecs.svc-rabbitmq.tf
@@ -14,6 +14,7 @@ data "template_file" "task_definition_rabbitmq" {
 resource "aws_ecs_task_definition" "rdss_datavault_rabbitmq" {
   family                = "rdss-datavault-rabbitmq"
   container_definitions = "${data.template_file.task_definition_rabbitmq.rendered}"
+  network_mode          = "bridge"
 
   volume {
     name      = "rabbitmq"

--- a/aws/ecs.svc-rabbitmq.tf
+++ b/aws/ecs.svc-rabbitmq.tf
@@ -15,6 +15,7 @@ resource "aws_ecs_task_definition" "rdss_datavault_rabbitmq" {
   family                = "rdss-datavault-rabbitmq"
   container_definitions = "${data.template_file.task_definition_rabbitmq.rendered}"
   network_mode          = "bridge"
+  task_role_arn         = "${aws_iam_role.ecs_task.arn}"
 
   volume {
     name      = "rabbitmq"

--- a/aws/ecs.svc-rabbitmq.tf
+++ b/aws/ecs.svc-rabbitmq.tf
@@ -6,6 +6,7 @@ data "template_file" "task_definition_rabbitmq" {
     container_name   = "rdss-datavault-rabbitmq"
     log_group_region = "${var.aws_region}"
     log_group_name   = "${aws_cloudwatch_log_group.datavault.name}"
+    rabbitmq_password   = "${var.rabbitmq_password}"
     volume_name      = "rabbitmq"
   }
 }

--- a/aws/ecs.svc-rabbitmq.tf
+++ b/aws/ecs.svc-rabbitmq.tf
@@ -24,9 +24,170 @@ resource "aws_ecs_task_definition" "rdss_datavault_rabbitmq" {
 }
 
 resource "aws_ecs_service" "rdss_datavault_rabbitmq" {
-  name            = "rdss-datavault-rabbitmq"
-  cluster         = "${aws_ecs_cluster.main.id}"
-  task_definition = "${aws_ecs_task_definition.rdss_datavault_rabbitmq.arn}"
-  desired_count   = 1
-  depends_on      = ["aws_iam_role_policy.ecs_service"]
+  name                              = "rdss-datavault-rabbitmq"
+  cluster                           = "${aws_ecs_cluster.main.id}"
+  task_definition                   = "${aws_ecs_task_definition.rdss_datavault_rabbitmq.arn}"
+  desired_count                     = 1
+  depends_on                        = ["aws_iam_role_policy.ecs_service"]
+  health_check_grace_period_seconds = 300
+
+  load_balancer {
+    elb_name       = "${aws_elb.rdss_datavault_rabbitmq.name}"
+    container_name = "rdss-datavault-rabbitmq"
+    container_port = 15672
+  }
+}
+
+resource "aws_route53_record" "rdss_datavault_rabbitmq" {
+  zone_id = "${aws_route53_zone.internal.zone_id}"
+  name    = "rabbitmq.${aws_route53_zone.internal.name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_elb.rdss_datavault_rabbitmq.dns_name}"
+    zone_id                = "${aws_elb.rdss_datavault_rabbitmq.zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_elb" "rdss_datavault_rabbitmq" {
+  # RabbitMQ uses multiple ports, so we have to use a Classic Load Balancer instead of an Application/Network Load Balancer
+  name            = "rdss-datavault-rabbitmq-lb"
+  internal        = true
+  subnets         = ["${data.aws_subnet.a.id}", "${data.aws_subnet.b.id}", "${data.aws_subnet.c.id}"]
+  security_groups = ["${aws_security_group.rdss_datavault_rabbitmq.id}"]
+  tags            = "${var.aws_cost_tags}"
+
+  listener {
+    instance_port     = "4369"
+    instance_protocol = "tcp"
+    lb_port           = "4369"
+    lb_protocol       = "tcp"
+  }
+
+  listener {
+    instance_port     = "5671"
+    instance_protocol = "tcp"
+    lb_port           = "5671"
+    lb_protocol       = "tcp"
+  }
+
+  listener {
+    instance_port     = "5672"
+    instance_protocol = "tcp"
+    lb_port           = "5672"
+    lb_protocol       = "tcp"
+  }
+
+  listener {
+    instance_port     = "15671"
+    instance_protocol = "tcp"
+    lb_port           = "15671"
+    lb_protocol       = "tcp"
+  }
+
+  listener {
+    instance_port     = "15672"
+    instance_protocol = "tcp"
+    lb_port           = "15672"
+    lb_protocol       = "tcp"
+  }
+
+  listener {
+    instance_port     = "25672"
+    instance_protocol = "tcp"
+    lb_port           = "25672"
+    lb_protocol       = "tcp"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 2
+    target              = "TCP:15672"
+    interval            = 5
+  }
+}
+
+resource "aws_security_group" "rdss_datavault_rabbitmq" {
+  description = "Controls access to RabbitMQ"
+  vpc_id      = "${data.aws_vpc.main.id}"
+  name        = "rdss-datavault-rabbitmq-sg"
+  tags        = "${var.aws_cost_tags}"
+}
+
+resource "aws_security_group_rule" "rdss_datavault_rabbitmq_ingress_4369" {
+  # This cannot be specified as an inline ingress block in aws_security_group.rdss_datavault_rabbitmq
+  # as this causes a cyclic dependency error
+  security_group_id        = "${aws_security_group.rdss_datavault_rabbitmq.id}"
+  type                     = "ingress"
+  from_port                = 4369
+  to_port                  = 4369
+  protocol                 = "tcp"
+  cidr_blocks              = ["${data.aws_vpc.main.cidr_block}"]
+}
+
+resource "aws_security_group_rule" "rdss_datavault_rabbitmq_ingress_5671" {
+  # This cannot be specified as an inline ingress block in aws_security_group.rdss_datavault_rabbitmq
+  # as this causes a cyclic dependency error
+  security_group_id        = "${aws_security_group.rdss_datavault_rabbitmq.id}"
+  type                     = "ingress"
+  from_port                = 5671
+  to_port                  = 5671
+  protocol                 = "tcp"
+  cidr_blocks              = ["${data.aws_vpc.main.cidr_block}"]
+}
+
+resource "aws_security_group_rule" "rdss_datavault_rabbitmq_ingress_5672" {
+  # This cannot be specified as an inline ingress block in aws_security_group.rdss_datavault_rabbitmq
+  # as this causes a cyclic dependency error
+  security_group_id        = "${aws_security_group.rdss_datavault_rabbitmq.id}"
+  type                     = "ingress"
+  from_port                = 5672
+  to_port                  = 5672
+  protocol                 = "tcp"
+  cidr_blocks              = ["${data.aws_vpc.main.cidr_block}"]
+}
+
+resource "aws_security_group_rule" "rdss_datavault_rabbitmq_ingress_15671" {
+  # This cannot be specified as an inline ingress block in aws_security_group.rdss_datavault_rabbitmq
+  # as this causes a cyclic dependency error
+  security_group_id        = "${aws_security_group.rdss_datavault_rabbitmq.id}"
+  type                     = "ingress"
+  from_port                = 15671
+  to_port                  = 15671
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "rdss_datavault_rabbitmq_ingress_15672" {
+  # This cannot be specified as an inline ingress block in aws_security_group.rdss_datavault_rabbitmq
+  # as this causes a cyclic dependency error
+  security_group_id        = "${aws_security_group.rdss_datavault_rabbitmq.id}"
+  type                     = "ingress"
+  from_port                = 15672
+  to_port                  = 15672
+  protocol                 = "tcp"
+  cidr_blocks              = ["${data.aws_vpc.main.cidr_block}"]
+}
+
+resource "aws_security_group_rule" "rdss_datavault_rabbitmq_ingress_25672" {
+  # This cannot be specified as an inline ingress block in aws_security_group.rdss_datavault_rabbitmq
+  # as this causes a cyclic dependency error
+  security_group_id        = "${aws_security_group.rdss_datavault_rabbitmq.id}"
+  type                     = "ingress"
+  from_port                = 25672
+  to_port                  = 25672
+  protocol                 = "tcp"
+  cidr_blocks              = ["${data.aws_vpc.main.cidr_block}"]
+}
+
+resource "aws_security_group_rule" "rdss_datavault_rabbitmq_egress" {
+  # This cannot be specified as an inline egress block in aws_security_group.rdss_datavault_rabbitmq
+  # because of aws_security_group_rule.rdss_datavault_rabbitmq_ingress
+  security_group_id = "${aws_security_group.rdss_datavault_rabbitmq.id}"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
 }

--- a/aws/ecs.svc-web.tf
+++ b/aws/ecs.svc-web.tf
@@ -15,6 +15,7 @@ resource "aws_ecs_task_definition" "rdss_datavault_web" {
   family                = "rdss-datavault-web"
   container_definitions = "${data.template_file.task_definition_web.rendered}"
   network_mode          = "bridge"
+  task_role_arn         = "${aws_iam_role.ecs_task.arn}"
 }
 
 resource "aws_ecs_service" "rdss_datavault_web" {

--- a/aws/ecs.svc-web.tf
+++ b/aws/ecs.svc-web.tf
@@ -6,8 +6,7 @@ data "template_file" "task_definition_web" {
     container_name   = "rdss-datavault-web"
     log_group_region = "${var.aws_region}"
     log_group_name   = "${aws_cloudwatch_log_group.datavault.name}"
-    # This is the gateway of the Docker daemon, and only works as long as a) broker & web are on same host & b) Docker IP range doesn't change
-    broker_host       = "172.17.0.1"
+    broker_host      = "${aws_route53_record.rdss_datavault_broker.fqdn}"
   }
 }
 

--- a/aws/ecs.svc-web.tf
+++ b/aws/ecs.svc-web.tf
@@ -6,6 +6,8 @@ data "template_file" "task_definition_web" {
     container_name   = "rdss-datavault-web"
     log_group_region = "${var.aws_region}"
     log_group_name   = "${aws_cloudwatch_log_group.datavault.name}"
+    # This is the gateway of the Docker daemon, and only works as long as a) broker & web are on same host & b) Docker IP range doesn't change
+    broker_host       = "172.17.0.1"
   }
 }
 

--- a/aws/ecs.svc-web.tf
+++ b/aws/ecs.svc-web.tf
@@ -18,9 +18,87 @@ resource "aws_ecs_task_definition" "rdss_datavault_web" {
 }
 
 resource "aws_ecs_service" "rdss_datavault_web" {
-  name            = "rdss-datavault-web"
-  cluster         = "${aws_ecs_cluster.main.id}"
-  task_definition = "${aws_ecs_task_definition.rdss_datavault_web.arn}"
-  desired_count   = 1
-  depends_on      = ["aws_iam_role_policy.ecs_service"]
+  name                              = "rdss-datavault-web"
+  cluster                           = "${aws_ecs_cluster.main.id}"
+  task_definition                   = "${aws_ecs_task_definition.rdss_datavault_web.arn}"
+  desired_count                     = 1
+  depends_on                        = ["aws_iam_role_policy.ecs_service"]
+  health_check_grace_period_seconds = 300
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.rdss_datavault_web.arn}"
+    container_name   = "rdss-datavault-web"
+    container_port   = 8080
+  }
 }
+
+resource "aws_route53_record" "rdss_datavault_web" {
+  zone_id = "${aws_route53_zone.internal.zone_id}"
+  name    = "web.${aws_route53_zone.internal.name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.rdss_datavault_web.dns_name}"
+    zone_id                = "${aws_lb.rdss_datavault_web.zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_lb" "rdss_datavault_web" {
+  name                       = "rdss-datavault-web-lb"
+  # Set this to external for now, since we don't actually have an external DNS zone to access it through
+  internal                   = false
+  load_balancer_type         = "application"
+  security_groups            = ["${aws_security_group.rdss_datavault_web.id}"]
+  subnets                    = ["${data.aws_subnet.a.id}", "${data.aws_subnet.b.id}", "${data.aws_subnet.c.id}"]
+  tags                       = "${var.aws_cost_tags}"
+}
+
+resource "aws_lb_listener" "rdss_datavault_web" {
+  load_balancer_arn = "${aws_lb.rdss_datavault_web.arn}"
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.rdss_datavault_web.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_target_group" "rdss_datavault_web" {
+  name        = "rdss-datavault-web-lb-tg"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = "${data.aws_vpc.main.id}"
+  target_type = "instance"
+}
+
+resource "aws_security_group" "rdss_datavault_web" {
+  description = "Controls access to web app"
+  vpc_id      = "${data.aws_vpc.main.id}"
+  name        = "rdss-datavault-web-sg"
+  tags        = "${var.aws_cost_tags}"
+}
+
+resource "aws_security_group_rule" "rdss_datavault_web_ingress" {
+  # This cannot be specified as an inline ingress block in aws_security_group.rdss_datavault_web
+  # as this causes a cyclic dependency error
+  security_group_id        = "${aws_security_group.rdss_datavault_web.id}"
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  cidr_blocks              = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "rdss_datavault_web_egress" {
+  # This cannot be specified as an inline egress block in aws_security_group.rdss_datavault_web
+  # because of aws_security_group_rule.rdss_datavault_web_ingress
+  security_group_id = "${aws_security_group.rdss_datavault_web.id}"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+

--- a/aws/ecs.svc-web.tf
+++ b/aws/ecs.svc-web.tf
@@ -12,6 +12,7 @@ data "template_file" "task_definition_web" {
 resource "aws_ecs_task_definition" "rdss_datavault_web" {
   family                = "rdss-datavault-web"
   container_definitions = "${data.template_file.task_definition_web.rendered}"
+  network_mode          = "bridge"
 }
 
 resource "aws_ecs_service" "rdss_datavault_web" {

--- a/aws/ecs.svc-worker.tf
+++ b/aws/ecs.svc-worker.tf
@@ -19,6 +19,7 @@ data "template_file" "task_definition_worker" {
 resource "aws_ecs_task_definition" "rdss_datavault_worker" {
   family                = "rdss-datavault-worker"
   container_definitions = "${data.template_file.task_definition_worker.rendered}"
+  network_mode          = "bridge"
 
   # This volume has to be shared with the broker task, in order for the broker to access the metadata after the worker has updated it
   # That's a bug - the worker should instead send the metadata back via rabbitmq - once it's fixed the volume can be removed/unshared

--- a/aws/ecs.svc-worker.tf
+++ b/aws/ecs.svc-worker.tf
@@ -10,8 +10,7 @@ data "template_file" "task_definition_worker" {
     archive_bucket_name = "${aws_s3_bucket.archive.bucket}"
     mysql_host          = "${aws_db_instance.datavault.address}"
     mysql_password      = "${var.mysql_password}"
-    # This is the gateway of the Docker daemon, and only works as long as a) broker & rabbitmq are on same host & b) Docker IP range doesn't change
-    rabbitmq_host       = "172.17.0.1"
+    rabbitmq_host       = "${aws_route53_record.rdss_datavault_rabbitmq.fqdn}"
     rabbitmq_password   = "${var.rabbitmq_password}"
     volume_name         = "datavault_working_data"
   }

--- a/aws/ecs.svc-worker.tf
+++ b/aws/ecs.svc-worker.tf
@@ -21,6 +21,7 @@ resource "aws_ecs_task_definition" "rdss_datavault_worker" {
   family                = "rdss-datavault-worker"
   container_definitions = "${data.template_file.task_definition_worker.rendered}"
   network_mode          = "bridge"
+  task_role_arn         = "${aws_iam_role.ecs_task.arn}"
 
   # This volume has to be shared with the broker task, in order for the broker to access the metadata after the worker has updated it
   # That's a bug - the worker should instead send the metadata back via rabbitmq - once it's fixed the volume can be removed/unshared

--- a/aws/ecs.svc-worker.tf
+++ b/aws/ecs.svc-worker.tf
@@ -10,6 +10,8 @@ data "template_file" "task_definition_worker" {
     archive_bucket_name = "${aws_s3_bucket.archive.bucket}"
     mysql_host          = "${aws_db_instance.datavault.address}"
     mysql_password      = "${var.mysql_password}"
+    rabbitmq_host       = "127.0.0.1"
+    rabbitmq_password   = "${var.rabbitmq_password}"
     volume_name         = "datavault_working_data"
   }
 }

--- a/aws/ecs.svc-worker.tf
+++ b/aws/ecs.svc-worker.tf
@@ -10,7 +10,8 @@ data "template_file" "task_definition_worker" {
     archive_bucket_name = "${aws_s3_bucket.archive.bucket}"
     mysql_host          = "${aws_db_instance.datavault.address}"
     mysql_password      = "${var.mysql_password}"
-    rabbitmq_host       = "127.0.0.1"
+    # This is the gateway of the Docker daemon, and only works as long as a) broker & rabbitmq are on same host & b) Docker IP range doesn't change
+    rabbitmq_host       = "172.17.0.1"
     rabbitmq_password   = "${var.rabbitmq_password}"
     volume_name         = "datavault_working_data"
   }

--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -2,9 +2,21 @@ resource "aws_efs_file_system" "docker_volumes" {
   tags           = "${var.aws_cost_tags}"
 }
 
-resource "aws_efs_mount_target" "docker_volumes" {
+resource "aws_efs_mount_target" "docker_volumes_a" {
   file_system_id  = "${aws_efs_file_system.docker_volumes.id}"
   subnet_id       = "${data.aws_subnet.a.id}"
+  security_groups = [ "${aws_security_group.efs.id}" ]
+}
+
+resource "aws_efs_mount_target" "docker_volumes_b" {
+  file_system_id  = "${aws_efs_file_system.docker_volumes.id}"
+  subnet_id       = "${data.aws_subnet.b.id}"
+  security_groups = [ "${aws_security_group.efs.id}" ]
+}
+
+resource "aws_efs_mount_target" "docker_volumes_c" {
+  file_system_id  = "${aws_efs_file_system.docker_volumes.id}"
+  subnet_id       = "${data.aws_subnet.c.id}"
   security_groups = [ "${aws_security_group.efs.id}" ]
 }
 

--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -4,7 +4,7 @@ resource "aws_efs_file_system" "docker_volumes" {
 
 resource "aws_efs_mount_target" "docker_volumes" {
   file_system_id  = "${aws_efs_file_system.docker_volumes.id}"
-  subnet_id       = "${data.aws_subnet.main.id}"
+  subnet_id       = "${data.aws_subnet.a.id}"
   security_groups = [ "${aws_security_group.efs.id}" ]
 }
 

--- a/aws/rds.tf
+++ b/aws/rds.tf
@@ -8,6 +8,7 @@ resource "aws_db_instance" "datavault" {
   username               = "datavault"
   password               = "${var.mysql_password}"
   parameter_group_name   = "default.mysql5.7"
+  publicly_accessible    = true
   tags                   = "${var.aws_cost_tags}"
   vpc_security_group_ids = [ "${aws_security_group.rds.id}" ]
 }
@@ -23,5 +24,12 @@ resource "aws_security_group" "rds" {
     from_port       = 3306
     to_port         = 3306
     security_groups = [ "${aws_security_group.instance_sg.id}" ]
+  }
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 3306
+    to_port         = 3306
+    cidr_blocks     = [ "${var.aws_admin_cidr_ingress}" ]
   }
 }

--- a/aws/route53.tf
+++ b/aws/route53.tf
@@ -1,0 +1,5 @@
+resource "aws_route53_zone" "internal" {
+  name   = "internal.datavault.rdss.com"
+  vpc_id = "${data.aws_vpc.main.id}"
+  tags   = "${var.aws_cost_tags}"
+}

--- a/aws/templates/rdss-datavault-broker.json
+++ b/aws/templates/rdss-datavault-broker.json
@@ -51,8 +51,7 @@
     "name": "${container_name}",
     "portMappings": [
       {
-        "containerPort": 8080,
-        "hostPort": 8080
+        "containerPort": 8080
       }
     ]
 

--- a/aws/templates/rdss-datavault-broker.json
+++ b/aws/templates/rdss-datavault-broker.json
@@ -40,6 +40,13 @@
         "containerPath": "/tmp/datavault"
       }
     ],
-    "name": "${container_name}"
+    "name": "${container_name}",
+    "portMappings": [
+      {
+        "containerPort": 8080,
+        "hostPort": 8080
+      }
+    ]
+
   }
 ]

--- a/aws/templates/rdss-datavault-broker.json
+++ b/aws/templates/rdss-datavault-broker.json
@@ -19,6 +19,14 @@
         "value": "${rabbitmq_password}"
       },
       {
+        "name": "AWS_ACCESS_KEY_ID",
+        "value": ""
+      },
+      {
+        "name": "AWS_SECRET_KEY_ID",
+        "value": ""
+      },
+      {
         "name": "AWS_S3_BUCKET",
         "value": "${archive_bucket_name}"
       }

--- a/aws/templates/rdss-datavault-broker.json
+++ b/aws/templates/rdss-datavault-broker.json
@@ -12,11 +12,11 @@
       },
       {
         "name": "RABBITMQ_HOST",
-        "value": "rdss-datavault-rabbitmq"
+        "value": "${rabbitmq_host}"
       },
       {
         "name": "RABBITMQ_PASSWORD",
-        "value": "efgh5678"
+        "value": "${rabbitmq_password}"
       },
       {
         "name": "AWS_S3_BUCKET",

--- a/aws/templates/rdss-datavault-rabbitmq.json
+++ b/aws/templates/rdss-datavault-rabbitmq.json
@@ -31,12 +31,28 @@
     "name": "${container_name}",
     "portMappings": [
       {
+        "containerPort": 4369,
+        "hostPort": 4369
+      },
+      {
+        "containerPort": 5671,
+        "hostPort": 5671
+      },
+      {
         "containerPort": 5672,
         "hostPort": 5672
       },
       {
+        "containerPort": 15671,
+        "hostPort": 15671
+      },
+      {
         "containerPort": 15672,
         "hostPort": 15672
+      },
+      {
+        "containerPort": 25672,
+        "hostPort": 25672
       }
     ]
   }

--- a/aws/templates/rdss-datavault-rabbitmq.json
+++ b/aws/templates/rdss-datavault-rabbitmq.json
@@ -28,6 +28,16 @@
         "containerPath": "/var/lib/rabbitmq"
       }
     ],
-    "name": "${container_name}"
+    "name": "${container_name}",
+    "portMappings": [
+      {
+        "containerPort": 5672,
+        "hostPort": 5672
+      },
+      {
+        "containerPort": 15672,
+        "hostPort": 15672
+      }
+    ]
   }
 ]

--- a/aws/templates/rdss-datavault-rabbitmq.json
+++ b/aws/templates/rdss-datavault-rabbitmq.json
@@ -8,7 +8,7 @@
       },
       {
         "name": "RABBITMQ_DEFAULT_PASS",
-        "value": "efgh5678"
+        "value": "${rabbitmq_password}"
       }
     ],
     "essential": true,

--- a/aws/templates/rdss-datavault-web.json
+++ b/aws/templates/rdss-datavault-web.json
@@ -1,6 +1,12 @@
 [
   {
     "cpu": 256,
+    "environment": [
+      {
+        "name": "BROKER_HOST",
+        "value": "${broker_host}"
+      }
+    ],
     "essential": true,
     "image": "${image_url}",
     "logConfiguration": {

--- a/aws/templates/rdss-datavault-web.json
+++ b/aws/templates/rdss-datavault-web.json
@@ -12,6 +12,12 @@
       }
     },
     "memory": 512,
-    "name": "${container_name}"
+    "name": "${container_name}",
+    "portMappings": [
+      {
+        "containerPort": 8080,
+        "hostPort": 80
+      }
+    ]
   }
 ]

--- a/aws/templates/rdss-datavault-web.json
+++ b/aws/templates/rdss-datavault-web.json
@@ -21,8 +21,7 @@
     "name": "${container_name}",
     "portMappings": [
       {
-        "containerPort": 8080,
-        "hostPort": 80
+        "containerPort": 8080
       }
     ]
   }

--- a/aws/templates/rdss-datavault-worker.json
+++ b/aws/templates/rdss-datavault-worker.json
@@ -19,6 +19,14 @@
         "value": "${rabbitmq_password}"
       },
       {
+        "name": "AWS_ACCESS_KEY_ID",
+        "value": ""
+      },
+      {
+        "name": "AWS_SECRET_KEY_ID",
+        "value": ""
+      },
+      {
         "name": "AWS_S3_BUCKET",
         "value": "${archive_bucket_name}"
       }

--- a/aws/templates/rdss-datavault-worker.json
+++ b/aws/templates/rdss-datavault-worker.json
@@ -11,8 +11,16 @@
         "value": "${mysql_password}"
       },
       {
+        "name": "RABBITMQ_HOST",
+        "value": "${rabbitmq_host}"
+      },
+      {
         "name": "RABBITMQ_PASSWORD",
-        "value": "efgh5678"
+        "value": "${rabbitmq_password}"
+      },
+      {
+        "name": "AWS_S3_BUCKET",
+        "value": "${archive_bucket_name}"
       }
     ],
     "essential": true,

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -92,3 +92,7 @@ variable "mysql_password" {
   description = "Master DB password"
 }
 
+variable "rabbitmq_password" {
+  description = "Master RabbitMQ password"
+}
+

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -43,6 +43,11 @@ variable "aws_asg_cost_tags" {
   ]
 }
 
+variable "aws_cloudwatch_log_retention_days" {
+  description = "Number of days to retain CloudWatch logs for"
+  default = 7
+}
+
 variable "aws_key_name" {
   description = "Name of AWS key pair"
   default     = "Datavault"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -60,7 +60,7 @@ variable "aws_public_key_path" {
 
 variable "aws_ecs_ec2_instance_type" {
   description = "AWS instance type"
-  default     = "t2.medium"
+  default     = "t2.small"
 }
 
 variable "aws_admin_cidr_ingress" {
@@ -82,9 +82,9 @@ variable "aws_ecs_optimized_amis" {
 variable "aws_ecs_asg_size" {
   description = "Numbers of servers in ASG"
   default = {
-    min = "1"
-    max = "1"
-    desired = "1"
+    min = "2"
+    max = "2"
+    desired = "2"
   }
 }
 

--- a/aws/vpc.tf
+++ b/aws/vpc.tf
@@ -2,8 +2,14 @@ data "aws_vpc" "main" {
   id   = "vpc-37d2b752"
 }
 
-data "aws_subnet" "main" {
+data "aws_subnet" "a" {
   id   = "subnet-cd0b9d94"
 }
 
+data "aws_subnet" "b" {
+  id   = "subnet-5f74233a"
+}
 
+data "aws_subnet" "c" {
+  id   = "subnet-12631c65"
+}

--- a/playbook.yml
+++ b/playbook.yml
@@ -56,22 +56,16 @@
         -f {{ item.1.dockerfile }} ."
       args:
         chdir: "{{ item.1.path }}"
-      when: item.0.changed
       with_subelements:
         - "{{ git_clone.results }}"
         - item.images
       tags:
         - "build"
-        # Ignore false ANSIBLE0016 claiming this task should be a handler
-        - skip_ansible_lint
 
     - name: "Publish images"
       command: docker push "{{ item.1.name }}"
-      when: item.0.changed
       with_subelements:
         - "{{ git_clone.results }}"
         - item.images
       tags:
         - "publish"
-        # Ignore false ANSIBLE0016 claiming this task should be a handler
-        - skip_ansible_lint


### PR DESCRIPTION
This contains all the work that's in #4 and so shouldn't really be merged until that has been done.

This adds load-balancers for the three containers that need them:
* An Application Load Balancer for the webapp. It has a Route53 entry, but since we don't have any domain names for now, that's just internal. Once Jisc bring this in with the rest of RDSS it can have an external entry. For now, the load-balancer is externally accessible, just to make testing easier
* An Application Load Balancer for the broker. It has an internal Route 53 entry, which is used by the webapp
* A Classic Load Balancer for RabbitMQ. I had to use a classic one because we need to use multiple ports. Again, it has an internal Route 53 entry, which is used by the broker and workers.